### PR TITLE
fix(aco-l6): docs — ACO Layer 5 actuating + add Layer 6 (ADR-0178)

### DIFF
--- a/core/console/corvin_console/aco/__init__.py
+++ b/core/console/corvin_console/aco/__init__.py
@@ -4,5 +4,6 @@ Layer 1: Observable Chat (chat_debug.jsonl) — implemented in chat_runtime.py
 Layer 2: Replay Engine        — replay.py
 Layer 3: Anomaly Detection    — anomaly_detector.py
 Layer 4: Autonomous Diagnosis — diagnosis.py
-Layer 5: Self-Repair Loop     — planned, opt-in only
+Layer 5: Self-Repair Loop     — repair_actions.py, actuating, ADR-0178
+Layer 6: Self-Improving Maintenance Loop — maintenance_loop.py + maintainer_capability.py, ADR-0178
 """


### PR DESCRIPTION
**Autonomous L6 maintenance PR — ADR-0178 Tier CONTRIBUTOR, end-to-end proof.**

This PR was produced by the ACO Layer-6 Self-Improving Maintenance Loop, fully automatically:

1. **Diagnosis** (L4): the `aco/__init__.py` module docstring was stale — it listed Layers 1–5 and marked Layer 5 *"planned, opt-in only"*. Since ADR-0178, Layer 5 is an **actuating** self-repair engine (`repair_actions.py`) and a **Layer 6** Self-Improving Maintenance Loop (`maintenance_loop.py` + `maintainer_capability.py`) exists.
2. **Patch**: generated by the engine running **tool-less** (`mode=restricted`, no Write/Edit/Bash) — pure text→text, so it cannot touch the filesystem or shell as a side effect.
3. **Gate chain**: signed `maintainer.commit` capability verified (deny-by-default), tests green, paths in-scope.
4. **Routing**: engine-generated patches are **always ack-gated** (`risk_class=engine_generated`, never in the low-risk allowlist) → this is a PR for human review, **never an auto-merge to main** — even though `--direct-main` was set.

Docstring-only change; zero behavior change. Safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)