### PR TITLE
fix(aco-l6): note actuating L5 lives in repair_actions.py

### DIFF
--- a/core/console/corvin_console/aco/repair.py
+++ b/core/console/corvin_console/aco/repair.py
@@ -11,6 +11,7 @@ Loss signal (LDD-style):
 
 Repair actions are log-only — they do NOT restart processes or modify code.
 Operator-level actions (gateway restart, engine swap) are outside this scope.
+For the actuating L5 engine that applies code-level repairs, see repair_actions.py.
 """
 from __future__ import annotations
 

--- a/core/console/corvin_console/aco/repair.py
+++ b/core/console/corvin_console/aco/repair.py
@@ -11,7 +11,7 @@ Loss signal (LDD-style):
 
 Repair actions are log-only — they do NOT restart processes or modify code.
 Operator-level actions (gateway restart, engine swap) are outside this scope.
-For the actuating L5 engine that applies code-level repairs, see repair_actions.py.
+For the actuating Layer 5 engine (self-healing actions), see repair_actions.py (ADR-0178).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**Autonomous nightly L6 maintenance PR — ADR-0178 Tier CONTRIBUTOR.**

- Diagnosis `repair-docstring-l5`: repair.py's module docstring describes Layer 5 as log-only. Since ADR-0178 the ACTUATING L5 lives in repair_actions.py. Add ONE line to the module docstring pointing to repair_actions.py for the actuating engine. Docstring only — change no code.
- Patch generated by the engine running **tool-less** (mode=restricted).
- Gates: signed maintainer.commit capability + tests green + paths in-scope.
- Engine-generated → **always ack-gated**: review + merge here, never auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)